### PR TITLE
Discard local changes on initial install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,4 +36,4 @@ FROM build as vendor-dev
 ARG BUILD_ROOT_PATH
 
 WORKDIR ${BUILD_ROOT_PATH}
-RUN composer install
+RUN COMPOSER_DISCARD_CHANGES=true composer install


### PR DESCRIPTION
Composer will now ignore and discard local changes on initial installation of dependencies.

Fix #5.